### PR TITLE
Add cross-platform support (MPS/CPU fallbacks) for inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ conda create -n efficientsam3 python=3.12 -y
 conda activate efficientsam3
 
 pip install --upgrade pip
+
+# Install PyTorch (choose one based on your device):
+# - CUDA:    pip install torch==2.7.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126
+# - MPS/CPU: pip install torch==2.7.0 torchvision torchaudio
 pip install torch==2.7.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126
 
 # Install repo dependencies via the root pyproject (brings in SAM3 + Stage-1 extras)

--- a/README.md
+++ b/README.md
@@ -135,9 +135,11 @@ conda activate efficientsam3
 pip install --upgrade pip
 
 # Install PyTorch (choose one based on your device):
-# - CUDA:    pip install torch==2.7.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126
-# - MPS/CPU: pip install torch==2.7.0 torchvision torchaudio
+# CUDA (default):
 pip install torch==2.7.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126
+
+# MPS/CPU (Apple Silicon or CPU-only):
+pip install torch==2.7.0 torchvision torchaudio
 
 # Install repo dependencies via the root pyproject (brings in SAM3 + Stage-1 extras)
 pip install -e ".[stage1]"

--- a/README.md
+++ b/README.md
@@ -114,8 +114,13 @@ Stage 3: We fine-tune the complete pipeline using SAM3 data. <br>
 EfficientSAM3 purposely shares the same software contract as upstream SAM3:
 
 - **Python** ≥ 3.12
-- **PyTorch** 2.7.0 (CUDA 12.6 build recommended)
-- **CUDA**-capable GPUs with drivers that support CUDA ≥ 12.6
+- **PyTorch** 2.7.0
+- **Device**: NVIDIA GPU (CUDA), Apple Silicon (MPS), or CPU
+
+For non-CUDA platforms (MPS/CPU), install `scipy` for distance transform operations:
+```bash
+pip install scipy
+```
 
 Follow the exact environment setup from the [official SAM3 README](sam3/README.md) or use the condensed steps below:
 

--- a/eval/eval_coco.py
+++ b/eval/eval_coco.py
@@ -15,6 +15,7 @@ sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
 # Assuming running from root where 'sam3' package is located
 from sam3 import build_efficientsam3_image_model
 from sam3.model.sam3_image_processor import Sam3Processor
+from sam3.device import get_device
 
 def calculate_iou(pred_mask, gt_mask):
     intersection = np.logical_and(pred_mask, gt_mask).sum()
@@ -25,9 +26,12 @@ def calculate_iou(pred_mask, gt_mask):
 
 import time
 
-def evaluate_model(model_path, backbone, model_name, coco_root, split='val2017', num_samples=-1, device='cuda'):
+def evaluate_model(model_path, backbone, model_name, coco_root, split='val2017', num_samples=-1, device=None):
     print(f"Evaluating model: {model_path}")
     start_time = time.time()
+
+    if device is None:
+        device = get_device()
     
     # Load Model
     try:

--- a/eval/eval_coco.py
+++ b/eval/eval_coco.py
@@ -139,7 +139,8 @@ def main():
     parser.add_argument('--coco_root', type=str, default='data/coco', help='Path to COCO dataset')
     parser.add_argument('--output_dir', type=str, default='output', help='Directory containing models')
     parser.add_argument('--num_samples', type=int, default=-1, help='Number of samples to evaluate')
-    parser.add_argument('--device', type=str, default='cuda' if torch.cuda.is_available() else 'cpu')
+    from sam3.device import get_device
+    parser.add_argument('--device', type=str, default=str(get_device()))
     args = parser.parse_args()
 
     models_dir = args.output_dir

--- a/eval/eval_text_encoder_similarity.py
+++ b/eval/eval_text_encoder_similarity.py
@@ -258,7 +258,8 @@ def main() -> None:
         default=None,
         help="Optional SAM3 checkpoint path to use for the teacher (overrides checkpoint config.MODEL.RESUME)",
     )
-    parser.add_argument("--device", default="cuda")
+    from sam3.device import get_device
+    parser.add_argument("--device", default=str(get_device()))
     parser.add_argument("--batch-size", type=int, default=64)
     parser.add_argument(
         "--max-texts",

--- a/sam3/efficientsam3_examples/efficientsam3_for_sam1_task_example.py
+++ b/sam3/efficientsam3_examples/efficientsam3_for_sam1_task_example.py
@@ -34,12 +34,8 @@ os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
 sam3_root = os.path.join(os.path.dirname(sam3.__file__), "..")
 
 # Select the device for computation
-if torch.cuda.is_available():
-    device = torch.device("cuda")
-elif torch.backends.mps.is_available():
-    device = torch.device("mps")
-else:
-    device = torch.device("cpu")
+from sam3.device import get_device, get_autocast_device_type, get_autocast_dtype
+device = get_device()
 print(f"using device: {device}")
 
 # Setup device-specific optimizations
@@ -53,6 +49,9 @@ if device.type == "cuda":
         torch.backends.cuda.matmul.allow_tf32 = True
         torch.backends.cudnn.allow_tf32 = True
 elif device.type == "mps":
+    # use float16 for MPS (bfloat16 not fully supported)
+    autocast_context = torch.autocast("mps", dtype=torch.float16)
+    autocast_context.__enter__()
     print(
         "\nSupport for MPS devices is preliminary. SAM 3 is trained with CUDA and might "
         "give numerically different outputs and sometimes degraded performance on MPS. "
@@ -123,12 +122,8 @@ def main():
     assets_dir = os.path.join(script_dir, "../assets")
 
     parser = argparse.ArgumentParser(description='EfficientSAM3 Interactive Instance Segmentation')
-    parser.add_argument('--checkpoint', type=str, 
-<<<<<<< HEAD
-                       default='/home/simon7108528_msi_linux/e-drive/side_projects/efficientsam3/output/efficient_sam3_tinyvit_s.pt', #
-=======
-                       default='/home/simon7108528_msi_linux/e-drive/side_projects/efficientsam3/output/efficient_sam3_efficientvit_s.pt', #
->>>>>>> stage1_text_encoder
+    parser.add_argument('--checkpoint', type=str,
+                       default=None,
                        help='Path to EfficientSAM3 checkpoint')
     parser.add_argument('--image', type=str, 
                        default=os.path.join(assets_dir, 'images/truck.jpg'),
@@ -148,10 +143,6 @@ def main():
     args = parser.parse_args()
 
     if args.headless:
-<<<<<<< HEAD
-=======
-        # import matplotlib.pyplot as plt # Already imported globally
->>>>>>> stage1_text_encoder
         plt.show = lambda: None
         print("Running in headless mode - display disabled")
 

--- a/sam3/efficientsam3_examples/efficientsam3_image_predictor_example.py
+++ b/sam3/efficientsam3_examples/efficientsam3_image_predictor_example.py
@@ -112,8 +112,8 @@ def main():
     width, height = image_pil.size
     print(f"Image Size: {width}x{height}")
     
-    from sam3.device import get_autocast_device_type
-    dtype_context = torch.autocast(get_autocast_device_type(device), dtype=torch.bfloat16) if device.type == "cuda" else torch.no_grad()
+    from sam3.device import get_autocast_device_type, get_autocast_dtype
+    dtype_context = torch.autocast(get_autocast_device_type(device), dtype=get_autocast_dtype(device)) if device.type in ("cuda", "mps") else torch.no_grad()
     
     with dtype_context:
         print(f"Using confidence threshold: {args.threshold}")

--- a/sam3/efficientsam3_examples/efficientsam3_image_predictor_example.py
+++ b/sam3/efficientsam3_examples/efficientsam3_image_predictor_example.py
@@ -47,9 +47,10 @@ def parse_args():
 def main():
     args = parse_args()
     print("Setting up device...")
-    device = "cuda" if torch.cuda.is_available() else "cpu"
-    
-    if device == "cuda":
+    from sam3.device import get_device
+    device = get_device()
+
+    if device.type == "cuda":
         torch.backends.cuda.matmul.allow_tf32 = True
         torch.backends.cudnn.allow_tf32 = True
 
@@ -111,7 +112,8 @@ def main():
     width, height = image_pil.size
     print(f"Image Size: {width}x{height}")
     
-    dtype_context = torch.autocast("cuda", dtype=torch.bfloat16) if device == "cuda" else torch.no_grad()
+    from sam3.device import get_autocast_device_type
+    dtype_context = torch.autocast(get_autocast_device_type(device), dtype=torch.bfloat16) if device.type == "cuda" else torch.no_grad()
     
     with dtype_context:
         print(f"Using confidence threshold: {args.threshold}")

--- a/sam3/sam3/backbones/efficientvit/nn/__init__.py
+++ b/sam3/sam3/backbones/efficientvit/nn/__init__.py
@@ -2,4 +2,8 @@ from .act import *
 from .drop import *
 from .norm import *
 from .ops import *
-from .triton_rms_norm import *
+
+try:
+    from .triton_rms_norm import *
+except ImportError:
+    pass  # Triton is not available on non-CUDA platforms (e.g. macOS)

--- a/sam3/sam3/backbones/efficientvit/nn/norm.py
+++ b/sam3/sam3/backbones/efficientvit/nn/norm.py
@@ -4,8 +4,15 @@ import torch
 import torch.nn as nn
 from torch.nn.modules.batchnorm import _BatchNorm
 
-from .triton_rms_norm import TritonRMSNorm2dFunc
 from ..utils import build_kwargs_from_config
+
+# Try importing Triton-based RMSNorm (CUDA-only); fall back to pure PyTorch
+try:
+    from .triton_rms_norm import TritonRMSNorm2dFunc
+
+    _TRITON_AVAILABLE = True
+except ImportError:
+    _TRITON_AVAILABLE = False
 
 __all__ = ["LayerNorm2d", "TritonRMSNorm2d", "build_norm", "reset_bn", "set_norm_eps"]
 
@@ -19,9 +26,20 @@ class LayerNorm2d(nn.LayerNorm):
         return out
 
 
+def _rms_norm_2d_pytorch(x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor, eps: float) -> torch.Tensor:
+    """Pure PyTorch RMSNorm2d fallback for non-CUDA devices."""
+    # x: (M, C, H, W)
+    x_float = x.float()
+    rms = torch.sqrt(x_float.pow(2).mean(dim=1, keepdim=True) + eps)
+    x_normed = x_float / rms
+    return (x_normed * weight.view(1, -1, 1, 1) + bias.view(1, -1, 1, 1)).to(x.dtype)
+
+
 class TritonRMSNorm2d(nn.LayerNorm):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return TritonRMSNorm2dFunc.apply(x, self.weight, self.bias, self.eps)
+        if _TRITON_AVAILABLE and x.is_cuda:
+            return TritonRMSNorm2dFunc.apply(x, self.weight, self.bias, self.eps)
+        return _rms_norm_2d_pytorch(x, self.weight, self.bias, self.eps)
 
 
 # register normalization function here

--- a/sam3/sam3/backbones/efficientvit/nn/ops.py
+++ b/sam3/sam3/backbones/efficientvit/nn/ops.py
@@ -92,13 +92,14 @@ class UpSampleLayer(nn.Module):
         self.factor = None if self.size is not None else factor
         self.align_corners = align_corners
 
-    @torch.autocast(device_type="cuda", enabled=False)
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         if (self.size is not None and tuple(x.shape[-2:]) == self.size) or self.factor == 1:
             return x
-        if x.dtype in [torch.float16, torch.bfloat16]:
-            x = x.float()
-        return resize(x, self.size, self.factor, self.mode, self.align_corners)
+        device_type = x.device.type if x.device.type == "cuda" else "cpu"
+        with torch.autocast(device_type=device_type, enabled=False):
+            if x.dtype in [torch.float16, torch.bfloat16]:
+                x = x.float()
+            return resize(x, self.size, self.factor, self.mode, self.align_corners)
 
 
 class ConvPixelUnshuffleDownSampleLayer(nn.Module):
@@ -578,77 +579,77 @@ class LiteMLA(nn.Module):
             act_func=act_func[1],
         )
 
-    @torch.autocast(device_type="cuda", enabled=False)
     def relu_linear_att(self, qkv: torch.Tensor) -> torch.Tensor:
         B, _, H, W = list(qkv.size())
+        device_type = qkv.device.type if qkv.device.type == "cuda" else "cpu"
+        with torch.autocast(device_type=device_type, enabled=False):
+            if qkv.dtype == torch.float16:
+                qkv = qkv.float()
 
-        if qkv.dtype == torch.float16:
-            qkv = qkv.float()
+            qkv = torch.reshape(
+                qkv,
+                (
+                    B,
+                    -1,
+                    3 * self.dim,
+                    H * W,
+                ),
+            )
+            q, k, v = (
+                qkv[:, :, 0 : self.dim],
+                qkv[:, :, self.dim : 2 * self.dim],
+                qkv[:, :, 2 * self.dim :],
+            )
 
-        qkv = torch.reshape(
-            qkv,
-            (
-                B,
-                -1,
-                3 * self.dim,
-                H * W,
-            ),
-        )
-        q, k, v = (
-            qkv[:, :, 0 : self.dim],
-            qkv[:, :, self.dim : 2 * self.dim],
-            qkv[:, :, 2 * self.dim :],
-        )
+            # lightweight linear attention
+            q = self.kernel_func(q)
+            k = self.kernel_func(k)
 
-        # lightweight linear attention
-        q = self.kernel_func(q)
-        k = self.kernel_func(k)
+            # linear matmul
+            trans_k = k.transpose(-1, -2)
 
-        # linear matmul
-        trans_k = k.transpose(-1, -2)
+            v = F.pad(v, (0, 0, 0, 1), mode="constant", value=1)
+            vk = torch.matmul(v, trans_k)
+            out = torch.matmul(vk, q)
+            if out.dtype == torch.bfloat16:
+                out = out.float()
+            out = out[:, :, :-1] / (out[:, :, -1:] + self.eps)
 
-        v = F.pad(v, (0, 0, 0, 1), mode="constant", value=1)
-        vk = torch.matmul(v, trans_k)
-        out = torch.matmul(vk, q)
-        if out.dtype == torch.bfloat16:
-            out = out.float()
-        out = out[:, :, :-1] / (out[:, :, -1:] + self.eps)
+            out = torch.reshape(out, (B, -1, H, W))
+            return out
 
-        out = torch.reshape(out, (B, -1, H, W))
-        return out
-
-    @torch.autocast(device_type="cuda", enabled=False)
     def relu_quadratic_att(self, qkv: torch.Tensor) -> torch.Tensor:
         B, _, H, W = list(qkv.size())
+        device_type = qkv.device.type if qkv.device.type == "cuda" else "cpu"
+        with torch.autocast(device_type=device_type, enabled=False):
+            qkv = torch.reshape(
+                qkv,
+                (
+                    B,
+                    -1,
+                    3 * self.dim,
+                    H * W,
+                ),
+            )
+            q, k, v = (
+                qkv[:, :, 0 : self.dim],
+                qkv[:, :, self.dim : 2 * self.dim],
+                qkv[:, :, 2 * self.dim :],
+            )
 
-        qkv = torch.reshape(
-            qkv,
-            (
-                B,
-                -1,
-                3 * self.dim,
-                H * W,
-            ),
-        )
-        q, k, v = (
-            qkv[:, :, 0 : self.dim],
-            qkv[:, :, self.dim : 2 * self.dim],
-            qkv[:, :, 2 * self.dim :],
-        )
+            q = self.kernel_func(q)
+            k = self.kernel_func(k)
 
-        q = self.kernel_func(q)
-        k = self.kernel_func(k)
+            att_map = torch.matmul(k.transpose(-1, -2), q)  # b h n n
+            original_dtype = att_map.dtype
+            if original_dtype in [torch.float16, torch.bfloat16]:
+                att_map = att_map.float()
+            att_map = att_map / (torch.sum(att_map, dim=2, keepdim=True) + self.eps)  # b h n n
+            att_map = att_map.to(original_dtype)
+            out = torch.matmul(v, att_map)  # b h d n
 
-        att_map = torch.matmul(k.transpose(-1, -2), q)  # b h n n
-        original_dtype = att_map.dtype
-        if original_dtype in [torch.float16, torch.bfloat16]:
-            att_map = att_map.float()
-        att_map = att_map / (torch.sum(att_map, dim=2, keepdim=True) + self.eps)  # b h n n
-        att_map = att_map.to(original_dtype)
-        out = torch.matmul(v, att_map)  # b h d n
-
-        out = torch.reshape(out, (B, -1, H, W))
-        return out
+            out = torch.reshape(out, (B, -1, H, W))
+            return out
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         # generate multi-scale q, k, v

--- a/sam3/sam3/backbones/efficientvit/nn/ops.py
+++ b/sam3/sam3/backbones/efficientvit/nn/ops.py
@@ -4,6 +4,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from sam3.device import get_autocast_device_type
+
 from .act import build_act
 from .norm import build_norm
 from ..utils import get_same_padding, list_sum, resize, val2list, val2tuple
@@ -95,7 +97,7 @@ class UpSampleLayer(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         if (self.size is not None and tuple(x.shape[-2:]) == self.size) or self.factor == 1:
             return x
-        device_type = x.device.type if x.device.type == "cuda" else "cpu"
+        device_type = get_autocast_device_type(x.device)
         with torch.autocast(device_type=device_type, enabled=False):
             if x.dtype in [torch.float16, torch.bfloat16]:
                 x = x.float()

--- a/sam3/sam3/backbones/efficientvit/nn/ops.py
+++ b/sam3/sam3/backbones/efficientvit/nn/ops.py
@@ -583,7 +583,7 @@ class LiteMLA(nn.Module):
 
     def relu_linear_att(self, qkv: torch.Tensor) -> torch.Tensor:
         B, _, H, W = list(qkv.size())
-        device_type = qkv.device.type if qkv.device.type == "cuda" else "cpu"
+        device_type = get_autocast_device_type(qkv.device)
         with torch.autocast(device_type=device_type, enabled=False):
             if qkv.dtype == torch.float16:
                 qkv = qkv.float()
@@ -622,7 +622,7 @@ class LiteMLA(nn.Module):
 
     def relu_quadratic_att(self, qkv: torch.Tensor) -> torch.Tensor:
         B, _, H, W = list(qkv.size())
-        device_type = qkv.device.type if qkv.device.type == "cuda" else "cpu"
+        device_type = get_autocast_device_type(qkv.device)
         with torch.autocast(device_type=device_type, enabled=False):
             qkv = torch.reshape(
                 qkv,

--- a/sam3/sam3/device.py
+++ b/sam3/sam3/device.py
@@ -1,0 +1,24 @@
+"""Device utilities for cross-platform support (CUDA, MPS, CPU)."""
+
+import torch
+
+
+def get_device() -> torch.device:
+    """Return the best available device (CUDA > MPS > CPU)."""
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    if torch.backends.mps.is_available():
+        return torch.device("mps")
+    return torch.device("cpu")
+
+
+def get_autocast_device_type(device) -> str:
+    """Return a device type string suitable for ``torch.autocast``.
+
+    MPS does not fully support autocast, so we fall back to ``"cpu"`` for
+    non-CUDA devices.
+    """
+    device_type = device.type if isinstance(device, torch.device) else device
+    if device_type == "cuda":
+        return "cuda"
+    return "cpu"

--- a/sam3/sam3/device.py
+++ b/sam3/sam3/device.py
@@ -15,10 +15,21 @@ def get_device() -> torch.device:
 def get_autocast_device_type(device) -> str:
     """Return a device type string suitable for ``torch.autocast``.
 
-    MPS does not fully support autocast, so we fall back to ``"cpu"`` for
-    non-CUDA devices.
+    Returns the device type directly for CUDA and MPS (both support
+    ``torch.autocast``). Falls back to ``"cpu"`` for other devices.
     """
     device_type = device.type if isinstance(device, torch.device) else device
-    if device_type == "cuda":
-        return "cuda"
+    if device_type in ("cuda", "mps"):
+        return device_type
     return "cpu"
+
+
+def get_autocast_dtype(device) -> torch.dtype:
+    """Return a suitable autocast dtype for the given device.
+
+    CUDA supports bfloat16; MPS requires float16; CPU uses bfloat16.
+    """
+    device_type = device.type if isinstance(device, torch.device) else device
+    if device_type == "mps":
+        return torch.float16
+    return torch.bfloat16

--- a/sam3/sam3/eval/postprocessors.py
+++ b/sam3/sam3/eval/postprocessors.py
@@ -151,7 +151,7 @@ class PostProcessImage(nn.Module):
             return None
         if self.always_interpolate_masks_on_gpu:
             gpu_device = target_sizes.device
-            assert gpu_device.type == "cuda"
+            assert gpu_device.type in ("cuda", "mps")
             pred_masks = pred_masks.to(device=gpu_device)
         if consistent:
             assert keep is None, "TODO: implement?"
@@ -455,7 +455,7 @@ class PostProcessAPIVideo(PostProcessImage):
             meta_td = meta_td[tracked_obj_ids_idx[PROMPT_AXIS].cpu()]
             if self.always_interpolate_masks_on_gpu:
                 gpu_device = meta_td["original_size"].device
-                assert gpu_device.type == "cuda"
+                assert gpu_device.type in ("cuda", "mps")
                 tracked_objs_outs_td = tracked_objs_outs_td.to(device=gpu_device)
             frame_results_td = self(
                 tracked_objs_outs_td.unsqueeze(1),

--- a/sam3/sam3/model/decoder.py
+++ b/sam3/sam3/model/decoder.py
@@ -71,7 +71,7 @@ class TransformerDecoderLayer(nn.Module):
         return tensor if pos is None else tensor + pos
 
     def forward_ffn(self, tgt):
-        with torch.amp.autocast(device_type="cuda", enabled=False):
+        with torch.amp.autocast(device_type=tgt.device.type if tgt.device.type == "cuda" else "cpu", enabled=False):
             tgt2 = self.linear2(self.dropout3(self.activation(self.linear1(tgt))))
         tgt = tgt + self.dropout4(tgt2)
         tgt = self.norm3(tgt)
@@ -278,7 +278,7 @@ class TransformerDecoder(nn.Module):
             if resolution is not None and stride is not None:
                 feat_size = resolution // stride
                 coords_h, coords_w = self._get_coords(
-                    feat_size, feat_size, device="cuda"
+                    feat_size, feat_size, device="cpu"
                 )
                 self.compilable_cord_cache = (coords_h, coords_w)
                 self.compilable_stored_size = (feat_size, feat_size)
@@ -342,6 +342,11 @@ class TransformerDecoder(nn.Module):
         ):
             # good, hitting the cache, will be compilable
             coords_h, coords_w = self.compilable_cord_cache
+            # Ensure cached coords are on the same device as the input
+            if coords_h.device != reference_boxes.device:
+                coords_h = coords_h.to(reference_boxes.device)
+                coords_w = coords_w.to(reference_boxes.device)
+                self.compilable_cord_cache = (coords_h, coords_w)
         else:
             # cache miss, will create compilation issue
             # In case we're not compiling, we'll still rely on the dict-based cache

--- a/sam3/sam3/model/decoder.py
+++ b/sam3/sam3/model/decoder.py
@@ -17,6 +17,8 @@ from torchvision.ops.roi_align import RoIAlign
 
 from .act_ckpt_utils import activation_ckpt_wrapper
 
+from sam3.device import get_autocast_device_type
+
 from .box_ops import box_cxcywh_to_xyxy
 
 from .model_misc import (
@@ -71,7 +73,7 @@ class TransformerDecoderLayer(nn.Module):
         return tensor if pos is None else tensor + pos
 
     def forward_ffn(self, tgt):
-        with torch.amp.autocast(device_type=tgt.device.type if tgt.device.type in ("cuda", "mps") else "cpu", enabled=False):
+        with torch.amp.autocast(device_type=get_autocast_device_type(tgt.device), enabled=False):
             tgt2 = self.linear2(self.dropout3(self.activation(self.linear1(tgt))))
         tgt = tgt + self.dropout4(tgt2)
         tgt = self.norm3(tgt)

--- a/sam3/sam3/model/decoder.py
+++ b/sam3/sam3/model/decoder.py
@@ -71,7 +71,7 @@ class TransformerDecoderLayer(nn.Module):
         return tensor if pos is None else tensor + pos
 
     def forward_ffn(self, tgt):
-        with torch.amp.autocast(device_type=tgt.device.type if tgt.device.type == "cuda" else "cpu", enabled=False):
+        with torch.amp.autocast(device_type=tgt.device.type if tgt.device.type in ("cuda", "mps") else "cpu", enabled=False):
             tgt2 = self.linear2(self.dropout3(self.activation(self.linear1(tgt))))
         tgt = tgt + self.dropout4(tgt2)
         tgt = self.norm3(tgt)

--- a/sam3/sam3/model/geometry_encoders.py
+++ b/sam3/sam3/model/geometry_encoders.py
@@ -656,7 +656,10 @@ class SequenceGeometryEncoder(nn.Module):
             # We need to denormalize, and convert to [x, y, x, y]
             boxes_xyxy = box_cxcywh_to_xyxy(boxes)
             scale = torch.tensor([W, H, W, H], dtype=boxes_xyxy.dtype)
-            scale = scale.pin_memory().to(device=boxes_xyxy.device, non_blocking=True)
+            if boxes_xyxy.device.type == "cuda":
+                scale = scale.pin_memory().to(device=boxes_xyxy.device, non_blocking=True)
+            else:
+                scale = scale.to(device=boxes_xyxy.device)
             scale = scale.view(1, 1, 4)
             boxes_xyxy = boxes_xyxy * scale
             sampled = torchvision.ops.roi_align(

--- a/sam3/sam3/model/position_encoding.py
+++ b/sam3/sam3/model/position_encoding.py
@@ -43,8 +43,9 @@ class PositionEmbeddingSine(nn.Module):
                 (precompute_resolution // 16, precompute_resolution // 16),
                 (precompute_resolution // 32, precompute_resolution // 32),
             ]
+            from sam3.device import get_device
             for size in precompute_sizes:
-                tensors = torch.zeros((1, 1) + size, device="cuda")
+                tensors = torch.zeros((1, 1) + size, device=get_device())
                 self.forward(tensors)
                 # further clone and detach it in the cache (just to be safe)
                 self.cache[size] = self.cache[size].clone().detach()

--- a/sam3/sam3/model/sam3_image_processor.py
+++ b/sam3/sam3/model/sam3_image_processor.py
@@ -14,7 +14,10 @@ from torchvision.transforms import v2
 class Sam3Processor:
     """ """
 
-    def __init__(self, model, resolution=1008, device="cuda", confidence_threshold=0.5):
+    def __init__(self, model, resolution=1008, device=None, confidence_threshold=0.5):
+        if device is None:
+            from sam3.device import get_device
+            device = get_device()
         self.model = model
         self.resolution = resolution
         self.device = device

--- a/sam3/sam3/model/sam3_tracker_base.py
+++ b/sam3/sam3/model/sam3_tracker_base.py
@@ -164,10 +164,12 @@ class Sam3TrackerBase(torch.nn.Module):
             return torch.zeros(len(rel_pos_list), self.mem_dim, device=device)
 
         t_diff_max = max_abs_pos - 1 if max_abs_pos is not None else 1
-        pos_enc = (
-            torch.tensor(rel_pos_list).pin_memory().to(device=device, non_blocking=True)
-            / t_diff_max
-        )
+        rel_pos_tensor = torch.tensor(rel_pos_list)
+        if device is not None and str(device).startswith("cuda"):
+            rel_pos_tensor = rel_pos_tensor.pin_memory().to(device=device, non_blocking=True)
+        else:
+            rel_pos_tensor = rel_pos_tensor.to(device=device)
+        pos_enc = rel_pos_tensor / t_diff_max
         tpos_dim = self.hidden_dim
         pos_enc = get_1d_sine_pe(pos_enc, dim=tpos_dim)
         pos_enc = self.obj_ptr_tpos_proj(pos_enc)

--- a/sam3/sam3/model/sam3_tracker_utils.py
+++ b/sam3/sam3/model/sam3_tracker_utils.py
@@ -11,46 +11,16 @@ except ImportError:
     edt_triton = None  # Triton not available (e.g. macOS)
 
 
-def _edt_pytorch_fallback(masks: torch.Tensor) -> torch.Tensor:
-    """Pure PyTorch approximation of euclidean distance transform.
+def _edt_scipy(masks: torch.Tensor) -> torch.Tensor:
+    """Euclidean distance transform using scipy (fallback for non-CUDA platforms)."""
+    from scipy.ndimage import distance_transform_edt
 
-    This is a simple fallback for non-CUDA platforms where Triton is unavailable.
-    It uses iterative dilation to approximate the EDT.
-    """
-    # masks: (B, H, W) binary tensor where 1 = foreground
     B, H, W = masks.shape
-    # For zero masks return zeros
     result = torch.zeros_like(masks, dtype=torch.float32)
-    # Distance transform: for each foreground pixel, distance to nearest background
-    # Use scipy if available, otherwise use a simple iterative approach
-    try:
-        from scipy.ndimage import distance_transform_edt
-
-        masks_np = masks.cpu().numpy()
-        for b in range(B):
-            dt = distance_transform_edt(masks_np[b])
-            result[b] = torch.from_numpy(dt).to(result.device)
-    except ImportError:
-        # Fallback: approximate with iterative erosion
-        for b in range(B):
-            mask = masks[b].float()
-            dist = torch.zeros_like(mask)
-            remaining = mask.clone()
-            d = 0
-            while remaining.any():
-                d += 1
-                # Erode using max-pool of inverted mask
-                eroded = F.max_pool2d(
-                    (1 - remaining).unsqueeze(0).unsqueeze(0),
-                    kernel_size=3, stride=1, padding=1
-                ).squeeze(0).squeeze(0)
-                eroded = 1 - eroded
-                newly_removed = remaining * (1 - eroded)
-                dist += newly_removed * d
-                remaining = remaining * eroded
-                if d > max(H, W):
-                    break
-            result[b] = dist
+    masks_np = masks.cpu().numpy()
+    for b in range(B):
+        dt = distance_transform_edt(masks_np[b])
+        result[b] = torch.from_numpy(dt).to(result.device)
     return result
 
 
@@ -221,7 +191,7 @@ def sample_one_point_from_error_center(gt_masks, pred_masks, padding=True):
         padded_fp_masks = fp_masks
         padded_fn_masks = fn_masks
 
-    _edt_fn = edt_triton if edt_triton is not None else _edt_pytorch_fallback
+    _edt_fn = edt_triton if edt_triton is not None else _edt_scipy
     fn_mask_dt = _edt_fn(padded_fn_masks)
     fp_mask_dt = _edt_fn(padded_fp_masks)
     if padding:

--- a/sam3/sam3/model/sam3_tracker_utils.py
+++ b/sam3/sam3/model/sam3_tracker_utils.py
@@ -13,7 +13,13 @@ except ImportError:
 
 def _edt_scipy(masks: torch.Tensor) -> torch.Tensor:
     """Euclidean distance transform using scipy (fallback for non-CUDA platforms)."""
-    from scipy.ndimage import distance_transform_edt
+    try:
+        from scipy.ndimage import distance_transform_edt
+    except ImportError:
+        raise ImportError(
+            "scipy is required for distance transform on non-CUDA platforms (CPU/MPS). "
+            "Install with: pip install scipy"
+        ) from None
 
     B, H, W = masks.shape
     result = torch.zeros_like(masks, dtype=torch.float32)

--- a/sam3/sam3/model/sam3_tracker_utils.py
+++ b/sam3/sam3/model/sam3_tracker_utils.py
@@ -25,7 +25,7 @@ def _edt_pytorch_fallback(masks: torch.Tensor) -> torch.Tensor:
     # Use scipy if available, otherwise use a simple iterative approach
     try:
         from scipy.ndimage import distance_transform_edt
-        import numpy as np
+
         masks_np = masks.cpu().numpy()
         for b in range(B):
             dt = distance_transform_edt(masks_np[b])

--- a/sam3/sam3/model/sam3_tracker_utils.py
+++ b/sam3/sam3/model/sam3_tracker_utils.py
@@ -5,7 +5,53 @@ import torch
 import torch.nn.functional as F
 from numpy.typing import NDArray
 
-from sam3.model.edt import edt_triton
+try:
+    from sam3.model.edt import edt_triton
+except ImportError:
+    edt_triton = None  # Triton not available (e.g. macOS)
+
+
+def _edt_pytorch_fallback(masks: torch.Tensor) -> torch.Tensor:
+    """Pure PyTorch approximation of euclidean distance transform.
+
+    This is a simple fallback for non-CUDA platforms where Triton is unavailable.
+    It uses iterative dilation to approximate the EDT.
+    """
+    # masks: (B, H, W) binary tensor where 1 = foreground
+    B, H, W = masks.shape
+    # For zero masks return zeros
+    result = torch.zeros_like(masks, dtype=torch.float32)
+    # Distance transform: for each foreground pixel, distance to nearest background
+    # Use scipy if available, otherwise use a simple iterative approach
+    try:
+        from scipy.ndimage import distance_transform_edt
+        import numpy as np
+        masks_np = masks.cpu().numpy()
+        for b in range(B):
+            dt = distance_transform_edt(masks_np[b])
+            result[b] = torch.from_numpy(dt).to(result.device)
+    except ImportError:
+        # Fallback: approximate with iterative erosion
+        for b in range(B):
+            mask = masks[b].float()
+            dist = torch.zeros_like(mask)
+            remaining = mask.clone()
+            d = 0
+            while remaining.any():
+                d += 1
+                # Erode using max-pool of inverted mask
+                eroded = F.max_pool2d(
+                    (1 - remaining).unsqueeze(0).unsqueeze(0),
+                    kernel_size=3, stride=1, padding=1
+                ).squeeze(0).squeeze(0)
+                eroded = 1 - eroded
+                newly_removed = remaining * (1 - eroded)
+                dist += newly_removed * d
+                remaining = remaining * eroded
+                if d > max(H, W):
+                    break
+            result[b] = dist
+    return result
 
 
 def sample_box_points(
@@ -175,8 +221,9 @@ def sample_one_point_from_error_center(gt_masks, pred_masks, padding=True):
         padded_fp_masks = fp_masks
         padded_fn_masks = fn_masks
 
-    fn_mask_dt = edt_triton(padded_fn_masks)
-    fp_mask_dt = edt_triton(padded_fp_masks)
+    _edt_fn = edt_triton if edt_triton is not None else _edt_pytorch_fallback
+    fn_mask_dt = _edt_fn(padded_fn_masks)
+    fp_mask_dt = _edt_fn(padded_fp_masks)
     if padding:
         fn_mask_dt = fn_mask_dt[:, 1:-1, 1:-1]
         fp_mask_dt = fp_mask_dt[:, 1:-1, 1:-1]

--- a/sam3/sam3/model/sam3_tracking_predictor.py
+++ b/sam3/sam3/model/sam3_tracking_predictor.py
@@ -46,12 +46,14 @@ class Sam3TrackerPredictor(Sam3TrackerBase):
         self.max_point_num_in_prompt_enc = max_point_num_in_prompt_enc
         self.non_overlap_masks_for_output = non_overlap_masks_for_output
 
-        # Keep autocast enabled for the whole demo process when CUDA is available.
-        # (Avoid creating a CUDA autocast context on CPU-only environments.)
+        # Keep autocast enabled for the whole demo process when CUDA or MPS is available.
+        # (Avoid creating an autocast context on CPU-only environments.)
         self.bf16_context = None
-        if torch.cuda.is_available():
+        if torch.cuda.is_available() or torch.backends.mps.is_available():
+            from sam3.device import get_autocast_device_type, get_device
+            autocast_device = get_autocast_device_type(get_device())
             self.bf16_context = torch.autocast(
-                device_type="cuda", dtype=torch.bfloat16
+                device_type=autocast_device, dtype=torch.bfloat16
             )
             self.bf16_context.__enter__()  # keep using for the entire model process
 

--- a/sam3/sam3/model/sam3_tracking_predictor.py
+++ b/sam3/sam3/model/sam3_tracking_predictor.py
@@ -50,10 +50,11 @@ class Sam3TrackerPredictor(Sam3TrackerBase):
         # (Avoid creating an autocast context on CPU-only environments.)
         self.bf16_context = None
         if torch.cuda.is_available() or torch.backends.mps.is_available():
-            from sam3.device import get_autocast_device_type, get_device
-            autocast_device = get_autocast_device_type(get_device())
+            from sam3.device import get_autocast_device_type, get_autocast_dtype, get_device
+            device = get_device()
             self.bf16_context = torch.autocast(
-                device_type=autocast_device, dtype=torch.bfloat16
+                device_type=get_autocast_device_type(device),
+                dtype=get_autocast_dtype(device),
             )
             self.bf16_context.__enter__()  # keep using for the entire model process
 
@@ -690,8 +691,6 @@ class Sam3TrackerPredictor(Sam3TrackerBase):
             image=image,
             point_inputs=None,
             mask_inputs=mask_inputs,
-            gt_masks=None,
-            frames_to_add_correction_pt=[],
             output_dict={
                 "cond_frame_outputs": {},
                 "non_cond_frame_outputs": {},

--- a/sam3/sam3/model/sam3_video_inference.py
+++ b/sam3/sam3/model/sam3_video_inference.py
@@ -9,6 +9,7 @@ import torch.distributed as dist
 import torch.nn.functional as F
 
 from sam3 import perflib
+from sam3.device import get_autocast_device_type
 from sam3.logger import get_logger
 from sam3.model.act_ckpt_utils import clone_output_wrapper
 from sam3.model.box_ops import box_xywh_to_cxcywh, box_xyxy_to_xywh
@@ -477,9 +478,12 @@ class Sam3VideoInference(Sam3VideoBase):
 
             # slice those valid entries from the original outputs
             keep_idx = torch.nonzero(keep, as_tuple=True)[0]
-            keep_idx_gpu = keep_idx.pin_memory().to(
-                device=out_binary_masks.device, non_blocking=True
-            )
+            if out_binary_masks.device.type == "cuda":
+                keep_idx_gpu = keep_idx.pin_memory().to(
+                    device=out_binary_masks.device, non_blocking=True
+                )
+            else:
+                keep_idx_gpu = keep_idx.to(device=out_binary_masks.device)
 
             out_obj_ids = torch.index_select(out_obj_ids, 0, keep_idx)
             out_probs = torch.index_select(out_probs, 0, keep_idx)
@@ -795,7 +799,6 @@ class Sam3VideoInference(Sam3VideoBase):
         return inference_state
 
     @torch.inference_mode()
-    @torch.autocast(device_type="cuda", dtype=torch.bfloat16)
     def warm_up_compilation(self):
         """
         Warm up the model by running a dummy inference to compile the model. This is
@@ -805,10 +808,18 @@ class Sam3VideoInference(Sam3VideoBase):
             return
         self._warm_up_complete = False
         if self.device.type != "cuda":
-            raise RuntimeError(
-                f"The model must be on CUDA for warm-up compilation, got {self.device=}."
+            logger.warning(
+                "Warm-up compilation is only supported on CUDA devices. "
+                "Skipping on %s.",
+                self.device,
             )
+            return
 
+        # Use autocast for CUDA warm-up compilation
+        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+            return self._warm_up_compilation_impl()
+
+    def _warm_up_compilation_impl(self):
         # temporally set to single GPU temporarily for warm-up compilation
         orig_rank = self.rank
         orig_world_size = self.world_size
@@ -903,9 +914,16 @@ class Sam3VideoInference(Sam3VideoBase):
         )
         return frame_idx, self._postprocess_output(inference_state, out)
 
-    @torch.autocast(device_type="cuda", dtype=torch.bfloat16)
     def forward(self, input: BatchedDatapoint, is_inference: bool = False):
         """This method is only used for benchmark eval (not used in the demo)."""
+        autocast_ctx = torch.autocast(
+            device_type=get_autocast_device_type(self.device),
+            dtype=torch.bfloat16,
+        )
+        with autocast_ctx:
+            return self._forward_impl(input, is_inference)
+
+    def _forward_impl(self, input: BatchedDatapoint, is_inference: bool = False):
         # set the model to single GPU for benchmark evaluation (to be compatible with trainer)
         orig_rank = self.rank
         orig_world_size = self.world_size

--- a/sam3/sam3/model/sam3_video_inference.py
+++ b/sam3/sam3/model/sam3_video_inference.py
@@ -9,7 +9,7 @@ import torch.distributed as dist
 import torch.nn.functional as F
 
 from sam3 import perflib
-from sam3.device import get_autocast_device_type
+from sam3.device import get_autocast_device_type, get_autocast_dtype
 from sam3.logger import get_logger
 from sam3.model.act_ckpt_utils import clone_output_wrapper
 from sam3.model.box_ops import box_xywh_to_cxcywh, box_xyxy_to_xywh
@@ -918,7 +918,7 @@ class Sam3VideoInference(Sam3VideoBase):
         """This method is only used for benchmark eval (not used in the demo)."""
         autocast_ctx = torch.autocast(
             device_type=get_autocast_device_type(self.device),
-            dtype=torch.bfloat16,
+            dtype=get_autocast_dtype(self.device),
         )
         with autocast_ctx:
             return self._forward_impl(input, is_inference)

--- a/sam3/sam3/model/sam3_video_predictor.py
+++ b/sam3/sam3/model/sam3_video_predictor.py
@@ -282,21 +282,29 @@ class Sam3VideoPredictor:
             f"'{session_id}' ({session['state']['num_frames']} frames)"
             for session_id, session in self._ALL_INFERENCE_STATES.items()
         ]
-        session_stats_str = (
-            f"live sessions: [{', '.join(live_session_strs)}], GPU memory: "
-            f"{torch.cuda.memory_allocated() // 1024**2} MiB used and "
-            f"{torch.cuda.memory_reserved() // 1024**2} MiB reserved"
-            f" (max over time: {torch.cuda.max_memory_allocated() // 1024**2} MiB used "
-            f"and {torch.cuda.max_memory_reserved() // 1024**2} MiB reserved)"
-        )
+        if torch.cuda.is_available():
+            session_stats_str = (
+                f"live sessions: [{', '.join(live_session_strs)}], GPU memory: "
+                f"{torch.cuda.memory_allocated() // 1024**2} MiB used and "
+                f"{torch.cuda.memory_reserved() // 1024**2} MiB reserved"
+                f" (max over time: {torch.cuda.max_memory_allocated() // 1024**2} MiB used "
+                f"and {torch.cuda.max_memory_reserved() // 1024**2} MiB reserved)"
+            )
+        else:
+            session_stats_str = (
+                f"live sessions: [{', '.join(live_session_strs)}]"
+            )
         return session_stats_str
 
     def _get_torch_and_gpu_properties(self):
         """Get a string for PyTorch and GPU properties (for logging and debugging)."""
-        torch_and_gpu_str = (
-            f"torch: {torch.__version__} with CUDA arch {torch.cuda.get_arch_list()}, "
-            f"GPU device: {torch.cuda.get_device_properties(torch.cuda.current_device())}"
-        )
+        if torch.cuda.is_available():
+            torch_and_gpu_str = (
+                f"torch: {torch.__version__} with CUDA arch {torch.cuda.get_arch_list()}, "
+                f"GPU device: {torch.cuda.get_device_properties(torch.cuda.current_device())}"
+            )
+        else:
+            torch_and_gpu_str = f"torch: {torch.__version__}, device: {self.device}"
         return torch_and_gpu_str
 
     def shutdown(self):
@@ -335,15 +343,18 @@ class Sam3VideoPredictorMultiGPU(Sam3VideoPredictor):
         model_args.update(custom_model_kwargs)
 
         if gpus_to_use is None:
-            # if not specified, use only the current GPU by default
-            gpus_to_use = [torch.cuda.current_device()]
+            if torch.cuda.is_available():
+                gpus_to_use = [torch.cuda.current_device()]
+            else:
+                gpus_to_use = [0]  # placeholder for non-CUDA environments
 
         IS_MAIN_PROCESS = os.getenv("IS_MAIN_PROCESS", "1") == "1"
         if IS_MAIN_PROCESS:
             gpus_to_use = sorted(set(gpus_to_use))
             logger.info(f"using the following GPU IDs: {gpus_to_use}")
             assert len(gpus_to_use) > 0 and all(isinstance(i, int) for i in gpus_to_use)
-            assert all(0 <= i < torch.cuda.device_count() for i in gpus_to_use)
+            if torch.cuda.is_available():
+                assert all(0 <= i < torch.cuda.device_count() for i in gpus_to_use)
             os.environ["MASTER_ADDR"] = "localhost"
             os.environ["MASTER_PORT"] = f"{self._find_free_port()}"
             os.environ["RANK"] = "0"
@@ -353,8 +364,12 @@ class Sam3VideoPredictorMultiGPU(Sam3VideoPredictor):
         self.rank = int(os.environ["RANK"])
         self.world_size = int(os.environ["WORLD_SIZE"])
         self.rank_str = f"rank={self.rank} with world_size={self.world_size}"
-        self.device = torch.device(f"cuda:{self.gpus_to_use[self.rank]}")
-        torch.cuda.set_device(self.device)
+        if torch.cuda.is_available():
+            self.device = torch.device(f"cuda:{self.gpus_to_use[self.rank]}")
+            torch.cuda.set_device(self.device)
+        else:
+            from sam3.device import get_device
+            self.device = get_device()
         self.has_shutdown = False
         if self.rank == 0:
             logger.info("\n\n\n\t*** START loading model on all ranks ***\n\n")
@@ -474,7 +489,7 @@ class Sam3VideoPredictorMultiGPU(Sam3VideoPredictor):
             device_id=self.device,
         )
         # warm-up the NCCL process group by running a dummy all-reduce
-        tensor = torch.ones(1024, 1024).cuda()
+        tensor = torch.ones(1024, 1024, device=self.device)
         torch.distributed.all_reduce(tensor)
         logger.debug(f"started NCCL process group on {rank=} with {world_size=}")
 

--- a/sam3/sam3/model/utils/sam2_utils.py
+++ b/sam3/sam3/model/utils/sam2_utils.py
@@ -10,6 +10,7 @@ from threading import Thread
 import numpy as np
 import torch
 from PIL import Image
+from sam3.device import get_device
 from tqdm import tqdm
 
 
@@ -100,12 +101,14 @@ def load_video_frames(
     img_mean=(0.485, 0.456, 0.406),
     img_std=(0.229, 0.224, 0.225),
     async_loading_frames=False,
-    compute_device=torch.device("cuda"),
+    compute_device=None,
 ):
     """
     Load the video frames from video_path. The frames are resized to image_size as in
     the model and are loaded to GPU if offload_video_to_cpu=False. This is used by the demo.
     """
+    if compute_device is None:
+        compute_device = get_device()
     is_bytes = isinstance(video_path, bytes)
     is_str = isinstance(video_path, str)
     is_mp4_path = is_str and os.path.splitext(video_path)[-1] in [".mp4", ".MP4"]
@@ -141,7 +144,7 @@ def load_video_frames_from_jpg_images(
     img_mean=(0.485, 0.456, 0.406),
     img_std=(0.229, 0.224, 0.225),
     async_loading_frames=False,
-    compute_device=torch.device("cuda"),
+    compute_device=None,
 ):
     """
     Load the video frames from a directory of JPEG files ("<frame_index>.jpg" format).
@@ -151,6 +154,8 @@ def load_video_frames_from_jpg_images(
 
     You can load a frame asynchronously by setting `async_loading_frames` to `True`.
     """
+    if compute_device is None:
+        compute_device = get_device()
     if isinstance(video_path, str) and os.path.isdir(video_path):
         jpg_folder = video_path
     else:
@@ -207,9 +212,11 @@ def load_video_frames_from_video_file(
     offload_video_to_cpu,
     img_mean=(0.485, 0.456, 0.406),
     img_std=(0.229, 0.224, 0.225),
-    compute_device=torch.device("cuda"),
+    compute_device=None,
 ):
     """Load the video frames from a video file."""
+    if compute_device is None:
+        compute_device = get_device()
     import decord
 
     img_mean = torch.tensor(img_mean, dtype=torch.float32)[:, None, None]

--- a/sam3/sam3/model/vl_combiner.py
+++ b/sam3/sam3/model/vl_combiner.py
@@ -124,7 +124,7 @@ class SAM3VLBackbone(nn.Module):
         return output
 
     def forward_text(
-        self, captions, input_boxes=None, additional_text=None, device="cuda"
+        self, captions, input_boxes=None, additional_text=None, device=None
     ):
         return activation_ckpt_wrapper(self._forward_text_no_ack_ckpt)(
             captions=captions,
@@ -139,8 +139,11 @@ class SAM3VLBackbone(nn.Module):
         captions,
         input_boxes=None,
         additional_text=None,
-        device="cuda",
+        device=None,
     ):
+        if device is None:
+            from sam3.device import get_device
+            device = get_device()
         output = {}
 
         # Forward through text_encoder

--- a/sam3/sam3/model_builder.py
+++ b/sam3/sam3/model_builder.py
@@ -7,6 +7,7 @@ import torch
 import torch.nn as nn
 from huggingface_hub import hf_hub_download
 from iopath.common.file_io import g_pathmgr
+from sam3.device import get_device
 from sam3.model.decoder import (
     TransformerDecoder,
     TransformerDecoderLayer,
@@ -630,8 +631,7 @@ def _load_checkpoint(model, checkpoint_path):
 
 def _setup_device_and_mode(model, device, eval_mode):
     """Setup model device and evaluation mode."""
-    if device == "cuda":
-        model = model.cuda()
+    model = model.to(device)
     if eval_mode:
         model.eval()
     return model
@@ -639,7 +639,7 @@ def _setup_device_and_mode(model, device, eval_mode):
 
 def build_sam3_image_model(
     bpe_path=None,
-    device="cuda" if torch.cuda.is_available() else "cpu",
+    device=None,
     eval_mode=True,
     checkpoint_path=None,
     load_from_HF=True,
@@ -654,7 +654,7 @@ def build_sam3_image_model(
 
     Args:
         bpe_path: Path to the BPE tokenizer vocabulary
-        device: Device to load the model on ('cuda' or 'cpu')
+        device: Device to load the model on ('cuda', 'mps', or 'cpu'). Auto-detected if None.
         eval_mode: Whether to set the model to evaluation mode
         checkpoint_path: Optional path to model checkpoint
         enable_segmentation: Whether to enable segmentation head
@@ -666,6 +666,8 @@ def build_sam3_image_model(
     Returns:
         A SAM3 image model
     """
+    if device is None:
+        device = get_device()
     if bpe_path is None:
         bpe_path = os.path.join(
             os.path.dirname(__file__), "..", "assets", "bpe_simple_vocab_16e6.txt.gz"
@@ -907,7 +909,7 @@ def _create_student_vision_backbone(
 
 def build_efficientsam3_image_model(
     bpe_path=None,
-    device="cuda" if torch.cuda.is_available() else "cpu",
+    device=None,
     eval_mode=True,
     checkpoint_path=None,
     load_from_HF=False,
@@ -925,7 +927,7 @@ def build_efficientsam3_image_model(
 
     Args:
         bpe_path: Path to the BPE tokenizer vocabulary
-        device: Device to load the model on ('cuda' or 'cpu')
+        device: Device to load the model on ('cuda', 'mps', or 'cpu'). Auto-detected if None.
         eval_mode: Whether to set the model to evaluation mode
         checkpoint_path: Optional path to EfficientSAM3 model checkpoint
         load_from_HF: Whether to load checkpoint from HuggingFace (if available)
@@ -940,6 +942,8 @@ def build_efficientsam3_image_model(
     Returns:
         An EfficientSAM3 image model
     """
+    if device is None:
+        device = get_device()
     if efficientvit_model is not None:
         backbone_type = "efficientvit"
         model_name = efficientvit_model
@@ -1017,7 +1021,7 @@ def build_efficientsam3_video_model(
     has_presence_token: bool = True,
     strict_state_dict_loading: bool = False,
     apply_temporal_disambiguation: bool = True,
-    device="cuda" if torch.cuda.is_available() else "cpu",
+    device=None,
     compile: bool = False,
     backbone_type: str = "repvit",
     model_name: str = "m1.1",
@@ -1030,6 +1034,8 @@ def build_efficientsam3_video_model(
     (EfficientViT/RepViT/TinyViT) while keeping the same detector+tracker
     inference wrapper.
     """
+    if device is None:
+        device = get_device()
     if bpe_path is None:
         bpe_path = os.path.join(
             os.path.dirname(__file__), "..", "assets", "bpe_simple_vocab_16e6.txt.gz"
@@ -1153,7 +1159,7 @@ def build_sam3_video_model(
     geo_encoder_use_img_cross_attn: bool = True,
     strict_state_dict_loading: bool = True,
     apply_temporal_disambiguation: bool = True,
-    device="cuda" if torch.cuda.is_available() else "cpu",
+    device=None,
     compile=False,
 ) -> Sam3VideoInferenceWithInstanceInteractivity:
     """
@@ -1166,6 +1172,8 @@ def build_sam3_video_model(
     Returns:
         Sam3VideoInferenceWithInstanceInteractivity: The instantiated dense tracking model
     """
+    if device is None:
+        device = get_device()
     if bpe_path is None:
         bpe_path = os.path.join(
             os.path.dirname(__file__), "..", "assets", "bpe_simple_vocab_16e6.txt.gz"
@@ -1299,7 +1307,7 @@ def build_efficientsam3_video_model(
     has_presence_token: bool = True,
     strict_state_dict_loading: bool = False,
     apply_temporal_disambiguation: bool = True,
-    device="cuda" if torch.cuda.is_available() else "cpu",
+    device=None,
     compile=False,
     backbone_type="efficientvit",
     model_name="b0",
@@ -1319,6 +1327,8 @@ def build_efficientsam3_video_model(
     Returns:
         Sam3VideoInferenceWithInstanceInteractivity: The instantiated dense tracking model
     """
+    if device is None:
+        device = get_device()
     if efficientvit_model is not None:
         backbone_type = "efficientvit"
         model_name = efficientvit_model

--- a/sam3/sam3/sam/transformer.py
+++ b/sam3/sam3/sam/transformer.py
@@ -252,9 +252,10 @@ class Attention(nn.Module):
                 q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2)
             ).transpose(1, 2)
         else:
-            torch.backends.cuda.enable_flash_sdp(True)
-            torch.backends.cuda.enable_math_sdp(True)
-            torch.backends.cuda.enable_mem_efficient_sdp(True)
+            if torch.cuda.is_available():
+                torch.backends.cuda.enable_flash_sdp(True)
+                torch.backends.cuda.enable_math_sdp(True)
+                torch.backends.cuda.enable_mem_efficient_sdp(True)
             out = F.scaled_dot_product_attention(q, k, v, dropout_p=dropout_p)
 
         out = self._recombine_heads(out)
@@ -282,7 +283,8 @@ class RoPEAttention(Attention):
         self.compute_cis = partial(
             compute_axial_cis, dim=self.internal_dim // self.num_heads, theta=rope_theta
         )
-        device = torch.device("cuda") if torch.cuda.is_available() else None
+        from sam3.device import get_device
+        device = get_device()
         self.freqs_cis = self.compute_cis(
             end_x=feat_sizes[0], end_y=feat_sizes[1], device=device
         )
@@ -347,9 +349,10 @@ class RoPEAttention(Attention):
                 q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2)
             ).transpose(1, 2)
         else:
-            torch.backends.cuda.enable_flash_sdp(True)
-            torch.backends.cuda.enable_math_sdp(True)
-            torch.backends.cuda.enable_mem_efficient_sdp(True)
+            if torch.cuda.is_available():
+                torch.backends.cuda.enable_flash_sdp(True)
+                torch.backends.cuda.enable_math_sdp(True)
+                torch.backends.cuda.enable_mem_efficient_sdp(True)
             out = F.scaled_dot_product_attention(q, k, v, dropout_p=dropout_p)
 
         out = self._recombine_heads(out)


### PR DESCRIPTION
## Summary

  This PR adds cross-platform support for EfficientSAM3 inference, enabling
  the model to run on:
  - **NVIDIA GPU** (CUDA) - primary target, unchanged behavior
  - **Apple Silicon** (MPS) - new support
  - **CPU** - improved with proper fallbacks

  ## Changes

  ### Core
  - Add `sam3/device.py` with device detection utilities:
    - `get_device()`: Auto-detect best available device (CUDA > MPS > CPU)
    - `get_autocast_device_type()`: Return appropriate device type for
  autocast
    - `get_autocast_dtype()`: Return bfloat16 for CUDA/CPU, float16 for MPS

  ### CUDA-only components with fallbacks
  - **Triton RMSNorm**: Add pure PyTorch fallback for non-CUDA platforms
  - **Triton EDT**: Add scipy fallback for distance transform on MPS/CPU
    - scipy is lazily imported with clear error message if not installed

  ### Autocast improvements
  - Replace hardcoded `device_type="cuda"` with dynamic device detection
  - Update `decoder.py`, `ops.py`, and video inference modules

  ### Documentation
  - Update installation requirements for cross-platform support
  - Add PyTorch install options for MPS/CPU devices
  - Add note about scipy requirement for non-CUDA platforms

  ## Testing

  Tested on:
  - [x] CUDA (NVIDIA GPU) - no regression
  - [x] MPS (Apple Silicon) - works
  - [x] CPU - works

  ## Notes

  - CUDA users are unaffected - all Triton kernels are still used
  - MPS/CPU users need to install scipy: `pip install scipy`